### PR TITLE
PCWEB-16853 base branch 대상을 릴리즈 메인 브랜치에서 develop 브랜치로 수정

### DIFF
--- a/.github/workflows/rwp-update.yml
+++ b/.github/workflows/rwp-update.yml
@@ -100,11 +100,11 @@ jobs:
       - name: 릴리즈 브랜치 Origin으로 푸시
         run: git push origin release/${{ inputs.version || steps.get-new-version.outputs.new_version }} --no-verify
 
-      - name: 릴리즈 PR 생성
+      - name: 머지 PR 생성
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HEAD_BRANCH: release/${{ inputs.version || steps.get-new-version.outputs.new_version }}
-          BASE_BRANCH: ${{ inputs.mainBranch }}
+          BASE_BRANCH: ${{ inputs.devBranch }}
           TITLE: v${{ inputs.version || steps.get-new-version.outputs.new_version }}
           BODY: |
             v${{ inputs.version || steps.get-new-version.outputs.new_version }}


### PR DESCRIPTION
바로 main이나 master로 머지되는 pr을 생성하는 방법에서
develop을 base로 하는 pr을 생성하도록 수정했습니다